### PR TITLE
Bug on evaluation procedure and example for MINDlarge

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ of the corresponding modules.
         num_heads: 15
 ```
 
+For training the `NRMS` model on the `MINDlarge` dataset, execute the following command:
+
+```python
+python newsreclib/train.py experiment=nrms_mindlarge_pretrainedemb_celoss_bertsent
+```
+
+To understand how to adjust configuration files when transitioning from smaller to larger datasets, refer to the examples provided in `nrms_mindsmall_pretrainedemb_celoss_bertsent` and `nrms_mindlarge_pretrainedemb_celoss_bertsent`. These files will guide you in scaling your configurations appropriately.
+
+*Note:* The same procedure applies for the advanced configuration shown below.
+
 ## Advanced Configuration
 
 The advanced scenario depicts a more complex experimental setting.

--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -4,15 +4,25 @@ defaults:
   - _self_
   - data: null # choose datamodule with `test_dataloader()` for evaluation
   - model: null
+  - callbacks: default.yaml
   - logger: many_loggers.yaml
   - trainer: default.yaml
   - paths: default.yaml
   - extras: default.yaml
   - hydra: default.yaml
 
+  # experiment configs allow for version control of specific hyperparameters
+  # e.g. best hyperparameters for given model and datamodule
+  - experiment: null
+
+# task name, determines output directory path
 task_name: "eval"
 
+# tags to help you identify your experiments
+# you can overwrite this in experiment configs
+# overwrite from command line with `python train.py tags="[first_tag, second_tag]"`
 tags: ["eval"]
 
 # passing checkpoint path is necessary for evaluation
+# example: logs/train/runs/nrms_mindsmall_pretrainedemb_celoss_bertsent_s42/2024-03-08_07-48-40/checkpoints/last.ckpt
 ckpt_path: ???

--- a/configs/experiment/nrms_mindlarge_pretrainedemb_celoss_bertsent.yaml
+++ b/configs/experiment/nrms_mindlarge_pretrainedemb_celoss_bertsent.yaml
@@ -1,0 +1,42 @@
+# @package _global_
+
+# to execute this experiment run:
+# python train.py experiment=example
+
+defaults:
+  - override /data: mind_rec_bert_sent.yaml
+  - override /model: nrms.yaml
+  - override /callbacks: default.yaml
+  - override /logger: many_loggers.yaml
+  - override /trainer: gpu.yaml
+
+# all parameters below will be merged with parameters from default configurations set above
+# this allows you to overwrite only specified parameters
+
+tags: ["nrms", "mindlarge", "pretrainedemb", "celoss", "bertsent"]
+
+seed: 42
+
+data:
+  dataset_size: "large"
+
+model:
+  use_plm: False
+  pretrained_embeddings_path: ${paths.data_dir}MINDlarge_train/transformed_word_embeddings.npy
+  embed_dim: 300
+  num_heads: 15
+  query_dim: 200
+  dropout_probability: 0.2
+
+callbacks:
+  early_stopping:
+    patience: 5
+
+trainer:
+  max_epochs: 20
+
+logger:
+  wandb:
+    name: "nrms_mindlarge_pretrainedemb_celoss_bertsent_s42"
+    tags: ${tags}
+    group: "mind"


### PR DESCRIPTION
Faced issues with the `eval.yaml` file after running the command: 
`python eval.py experiment=nrms_mindsmall_pretrainedemb_celoss_bertsent.yaml`

Pull request addressing:
- 5b9c406e7c8c5a7e1bc32b3f3bf13ff4431d76a9 - A bug fix related to the issue.
- a6ef42cb6e8577c71a865d805a9ec687e2fb7587 - Additional documentation for the MINDlarge dataset.
$\hspace{5pt}$ - A sample configuration (`nrms_mindlarge_pretrainedemb_celoss_bertsent.yaml`).