### PR TITLE
Feat: save recommendations list

### DIFF
--- a/configs/model/caum.yaml
+++ b/configs/model/caum.yaml
@@ -47,12 +47,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/cen_news_rec.yaml
+++ b/configs/model/cen_news_rec.yaml
@@ -41,12 +41,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/dkn.yaml
+++ b/configs/model/dkn.yaml
@@ -33,12 +33,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/lstur.yaml
+++ b/configs/model/lstur.yaml
@@ -43,12 +43,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/manner_cr_module.yaml
+++ b/configs/model/manner_cr_module.yaml
@@ -34,12 +34,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/manner_module.yaml
+++ b/configs/model/manner_module.yaml
@@ -18,12 +18,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer: null
 scheduler: null

--- a/configs/model/miner.yaml
+++ b/configs/model/miner.yaml
@@ -39,12 +39,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/mins.yaml
+++ b/configs/model/mins.yaml
@@ -40,12 +40,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/naml.yaml
+++ b/configs/model/naml.yaml
@@ -38,12 +38,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/npa.yaml
+++ b/configs/model/npa.yaml
@@ -32,12 +32,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/nrms.yaml
+++ b/configs/model/nrms.yaml
@@ -35,12 +35,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/senti_debias.yaml
+++ b/configs/model/senti_debias.yaml
@@ -45,6 +45,8 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # loss coefficients
@@ -55,6 +57,8 @@ beta_coefficient: 10
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer: null
 

--- a/configs/model/sentirec.yaml
+++ b/configs/model/sentirec.yaml
@@ -41,12 +41,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/tanr.yaml
+++ b/configs/model/tanr.yaml
@@ -40,12 +40,16 @@ outputs:
       "target_sentiments",
       "hist_categories",
       "hist_sentiments",
+      "user_ids",
+      "cand_news_ids",
     ]
 
 # evaluation
 top_k_list: [5, 10]
 num_categ_classes: 18
 num_sent_classes: 3
+save_recs: False
+recs_fpath: "${paths.output_dir}/recommendations.json"
 
 optimizer:
   _target_: torch.optim.Adam

--- a/newsreclib/data/components/adressa_dataframe.py
+++ b/newsreclib/data/components/adressa_dataframe.py
@@ -548,7 +548,7 @@ class AdressaDataFrame(Dataset):
             log.info("Mapping uid to index.")
             behaviors["user"] = behaviors["uid"].apply(lambda x: uid2index.get(x, 0))
 
-            behaviors = behaviors[["user", "history", "candidates", "labels"]]
+            behaviors = behaviors[["uid", "user", "history", "candidates", "labels"]]
 
             # cache processed data
             log.info(
@@ -560,7 +560,7 @@ class AdressaDataFrame(Dataset):
 
     def _process_news_files(
         self, filepath
-    ) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str], Dict[str, int]]:
+    ) -> Tuple[Dict[str, str], Dict[str, str], Dict[str, str], Dict[str, str]]:
         """Processes the news data.
 
         Adapted from
@@ -604,7 +604,9 @@ class AdressaDataFrame(Dataset):
                                 == event_dict["category1"].split("|")[-1]
                             )
 
-        nid2index = {k: v for k, v in zip(news_title.keys(), range(1, len(news_title) + 1))}
+        nid2index = {
+            k: "N" + str(v) for k, v in zip(news_title.keys(), range(1, len(news_title) + 1))
+        }
 
         return news_title, news_category, news_subcategory, nid2index
 
@@ -664,7 +666,7 @@ class AdressaDataFrame(Dataset):
                         and event_dict["id"] in nid2index
                     ):
                         nindex = nid2index[event_dict["id"]]
-                        uid = event_dict["userId"]
+                        uid = "U" + str(event_dict["userId"])
 
                         if uid not in uid2index:
                             uid2index[uid] = len(uid2index)

--- a/newsreclib/data/components/batch.py
+++ b/newsreclib/data/components/batch.py
@@ -17,8 +17,10 @@ class RecommendationBatch(TypedDict):
             Dictionary of news from a the users' candidates, mapping news features to values.
         labels:
             Ground truth specifying whether the news is relevant to the user.
-        users:
-            Users included in the batch.
+        user_ids:
+            Original user IDs of the users included in the batch.
+        user_idx:
+            Indices of users included in the batch (e.g., for creating embedding matrix).
     """
 
     batch_hist: torch.Tensor
@@ -26,7 +28,8 @@ class RecommendationBatch(TypedDict):
     x_hist: Dict[str, Any]
     x_cand: Dict[str, Any]
     labels: torch.Tensor
-    users: torch.Tensor
+    user_ids: torch.Tensor
+    user_idx: torch.Tensor
 
 
 class NewsBatch(TypedDict):

--- a/newsreclib/data/components/mind_dataframe.py
+++ b/newsreclib/data/components/mind_dataframe.py
@@ -590,7 +590,7 @@ class MINDDataFrame(Dataset):
 
             # cache parsed behaviors
             log.info(f"Caching parsed behaviors of size {len(behaviors)} to {parsed_bhv_file}.")
-            behaviors = behaviors[["user", "history", "candidates", "labels"]]
+            behaviors = behaviors[["uid", "user", "history", "candidates", "labels"]]
             file_utils.to_tsv(behaviors, parsed_bhv_file)
 
         return behaviors

--- a/newsreclib/data/components/news_dataset.py
+++ b/newsreclib/data/components/news_dataset.py
@@ -101,6 +101,10 @@ class DatasetCollate:
     def _tokenize_df(self, df: pd.DataFrame) -> Dict[str, Any]:
         batch_out = {}
 
+        # news IDs (i.e., keep only numeric part of unique NID)
+        nids = np.array([int(nid.split("N")[-1]) for nid in df.index.values])
+        batch_out["news_ids"] = torch.from_numpy(nids).long()
+
         if not self.concatenate_inputs:
             # prepare text
             if not self.use_plm:

--- a/newsreclib/models/fair_rec/manner_cr_module.py
+++ b/newsreclib/models/fair_rec/manner_cr_module.py
@@ -60,6 +60,10 @@ class CRModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -86,6 +90,8 @@ class CRModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -97,6 +103,9 @@ class CRModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         self.criterion = self._get_loss(self.hparams.loss)
@@ -259,6 +268,8 @@ class CRModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -319,6 +330,9 @@ class CRModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -329,10 +343,12 @@ class CRModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -366,7 +382,7 @@ class CRModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -420,6 +436,8 @@ class CRModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -455,6 +473,9 @@ class CRModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -482,6 +503,19 @@ class CRModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/fair_rec/senti_debias_module.py
+++ b/newsreclib/models/fair_rec/senti_debias_module.py
@@ -283,6 +283,10 @@ class SentiDebiasModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         alpha_coefficient:
@@ -305,6 +309,8 @@ class SentiDebiasModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         alpha_coefficient: float,
         beta_coefficient: float,
@@ -322,6 +328,9 @@ class SentiDebiasModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         self.rec_loss = self._get_loss("cross_entropy_loss")
@@ -416,6 +425,8 @@ class SentiDebiasModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         _, bias_free_scores, _, _, _ = self.forward(batch)
 
@@ -445,6 +456,9 @@ class SentiDebiasModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             preds,
             targets,
@@ -454,6 +468,8 @@ class SentiDebiasModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
@@ -532,7 +548,7 @@ class SentiDebiasModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # collect step outputs for metric computation
         self.val_step_outputs = self._collect_step_outputs(
@@ -581,6 +597,8 @@ class SentiDebiasModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # collect step outputs for metric computation
@@ -603,6 +621,9 @@ class SentiDebiasModule(AbstractRecommneder):
 
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
+
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
 
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
@@ -631,6 +652,19 @@ class SentiDebiasModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/caum_module.py
+++ b/newsreclib/models/general_rec/caum_module.py
@@ -83,6 +83,10 @@ class CAUMModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -120,6 +124,8 @@ class CAUMModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -131,6 +137,9 @@ class CAUMModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -365,6 +374,8 @@ class CAUMModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -438,6 +449,9 @@ class CAUMModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -448,10 +462,12 @@ class CAUMModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -485,7 +501,7 @@ class CAUMModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -539,6 +555,8 @@ class CAUMModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -574,6 +592,9 @@ class CAUMModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -601,6 +622,19 @@ class CAUMModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/dkn_module.py
+++ b/newsreclib/models/general_rec/dkn_module.py
@@ -59,6 +59,10 @@ class DKNModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -84,6 +88,8 @@ class DKNModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -95,6 +101,9 @@ class DKNModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -244,6 +253,8 @@ class DKNModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -317,6 +328,9 @@ class DKNModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -327,10 +341,12 @@ class DKNModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -364,7 +380,7 @@ class DKNModule(AbstractRecommneder):
         self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -418,6 +434,8 @@ class DKNModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -453,6 +471,9 @@ class DKNModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -480,6 +501,19 @@ class DKNModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/lstur_module.py
+++ b/newsreclib/models/general_rec/lstur_module.py
@@ -77,6 +77,10 @@ class LSTURModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -110,6 +114,8 @@ class LSTURModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -122,6 +128,9 @@ class LSTURModule(AbstractRecommneder):
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
         self.num_users = self.hparams.num_users + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -281,7 +290,7 @@ class LSTURModule(AbstractRecommneder):
         )
         if not self.hparams.late_fusion:
             # encode user
-            user_vector = self.user_encoder(batch["users"], hist_news_vector_agg, hist_size)
+            user_vector = self.user_encoder(batch["user_idx"], hist_news_vector_agg, hist_size)
         else:
             # aggregate embeddings of clicked news
             user_vector = torch.div(hist_news_vector_agg.sum(dim=1), hist_size.unsqueeze(dim=-1))
@@ -299,6 +308,8 @@ class LSTURModule(AbstractRecommneder):
     def model_step(
         self, batch: RecommendationBatch
     ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
@@ -381,6 +392,9 @@ class LSTURModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -391,10 +405,12 @@ class LSTURModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -428,7 +444,7 @@ class LSTURModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -482,6 +498,8 @@ class LSTURModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -517,6 +535,9 @@ class LSTURModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -544,6 +565,19 @@ class LSTURModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/miner_module.py
+++ b/newsreclib/models/general_rec/miner_module.py
@@ -78,6 +78,10 @@ class MINERModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -109,6 +113,8 @@ class MINERModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -120,6 +126,9 @@ class MINERModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -328,6 +337,8 @@ class MINERModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores, user_vector = self.forward(batch)
 
@@ -411,6 +422,9 @@ class MINERModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -421,10 +435,12 @@ class MINERModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -458,7 +474,7 @@ class MINERModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -512,6 +528,8 @@ class MINERModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -547,6 +565,9 @@ class MINERModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -574,6 +595,19 @@ class MINERModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/mins_module.py
+++ b/newsreclib/models/general_rec/mins_module.py
@@ -69,6 +69,10 @@ class MINSModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -99,6 +103,8 @@ class MINSModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -110,6 +116,9 @@ class MINSModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -283,6 +292,8 @@ class MINSModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -356,6 +367,9 @@ class MINSModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -366,10 +380,12 @@ class MINSModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -403,7 +419,7 @@ class MINSModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -457,6 +473,8 @@ class MINSModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -492,6 +510,9 @@ class MINSModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -519,6 +540,19 @@ class MINSModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/naml_module.py
+++ b/newsreclib/models/general_rec/naml_module.py
@@ -69,6 +69,10 @@ class NAMLModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -99,6 +103,8 @@ class NAMLModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -110,6 +116,9 @@ class NAMLModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -291,6 +300,8 @@ class NAMLModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -364,6 +375,9 @@ class NAMLModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -374,10 +388,12 @@ class NAMLModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -411,7 +427,7 @@ class NAMLModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -465,6 +481,8 @@ class NAMLModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -500,6 +518,9 @@ class NAMLModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -527,6 +548,19 @@ class NAMLModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/npa_module.py
+++ b/newsreclib/models/general_rec/npa_module.py
@@ -64,6 +64,10 @@ class NPAModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -90,6 +94,8 @@ class NPAModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -101,6 +107,9 @@ class NPAModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -212,7 +221,7 @@ class NPAModule(AbstractRecommneder):
         )
 
         # project users
-        projected_users = self.user_projection(batch["users"])
+        projected_users = self.user_projection(batch["user_idx"])
 
         # encode user history
         hist_news_vector = self.news_encoder(batch["x_hist"]["title"], hist_size, projected_users)
@@ -246,6 +255,8 @@ class NPAModule(AbstractRecommneder):
     def model_step(
         self, batch: RecommendationBatch
     ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
@@ -328,6 +339,9 @@ class NPAModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -338,10 +352,12 @@ class NPAModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -375,7 +391,7 @@ class NPAModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -429,6 +445,8 @@ class NPAModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -464,6 +482,9 @@ class NPAModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -491,6 +512,19 @@ class NPAModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/nrms_module.py
+++ b/newsreclib/models/general_rec/nrms_module.py
@@ -62,6 +62,10 @@ class NRMSModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -89,6 +93,8 @@ class NRMSModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -100,6 +106,9 @@ class NRMSModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize loss
         if not self.hparams.dual_loss_training:
@@ -260,6 +269,8 @@ class NRMSModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores = self.forward(batch)
 
@@ -333,6 +344,9 @@ class NRMSModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -343,10 +357,12 @@ class NRMSModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -380,7 +396,7 @@ class NRMSModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -434,6 +450,8 @@ class NRMSModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -469,6 +487,9 @@ class NRMSModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -496,6 +517,19 @@ class NRMSModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/newsreclib/models/general_rec/tanr_module.py
+++ b/newsreclib/models/general_rec/tanr_module.py
@@ -71,6 +71,10 @@ class TANRModule(AbstractRecommneder):
             The number of topical categories.
         num_sent_classes:
             The number of sentiment classes.
+        save_recs:
+            Whether to save the recommendations (i.e., candidates news and corresponding scores) to disk in JSON format.
+        recs_fpath:
+            Path where to save the list of recommendations and corresponding scores for users.
         optimizer:
             Optimizer used for model training.
         scheduler:
@@ -101,6 +105,8 @@ class TANRModule(AbstractRecommneder):
         top_k_list: List[int],
         num_categ_classes: int,
         num_sent_classes: int,
+        save_recs: bool,
+        recs_fpath: Optional[str],
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
     ) -> None:
@@ -112,6 +118,9 @@ class TANRModule(AbstractRecommneder):
 
         self.num_categ_classes = self.hparams.num_categ_classes + 1
         self.num_sent_classes = self.hparams.num_sent_classes + 1
+
+        if self.hparams.save_recs:
+            assert isinstance(self.hparams.recs_fpath, str)
 
         # initialize recommendation loss
         if not self.hparams.dual_loss_training:
@@ -291,6 +300,8 @@ class TANRModule(AbstractRecommneder):
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
     ]:
         scores, topic_scores = self.forward(batch)
 
@@ -372,6 +383,9 @@ class TANRModule(AbstractRecommneder):
             [torch.where(mask_hist[n])[0].shape[0] for n in range(mask_hist.shape[0])]
         )
 
+        user_ids = batch["user_ids"]
+        cand_news_ids = batch["x_cand"]["news_ids"]
+
         return (
             loss,
             preds,
@@ -382,10 +396,12 @@ class TANRModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         )
 
     def training_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log loss
         self.train_loss(loss)
@@ -419,7 +435,7 @@ class TANRModule(AbstractRecommneder):
         self.training_step_outputs = self._clear_epoch_outputs(self.training_step_outputs)
 
     def validation_step(self, batch: RecommendationBatch, batch_idx: int):
-        loss, preds, targets, cand_news_size, _, _, _, _, _ = self.model_step(batch)
+        loss, preds, targets, cand_news_size, _, _, _, _, _, _, _ = self.model_step(batch)
 
         # update and log metrics
         self.val_loss(loss)
@@ -473,6 +489,8 @@ class TANRModule(AbstractRecommneder):
             target_sentiments,
             hist_categories,
             hist_sentiments,
+            user_ids,
+            cand_news_ids,
         ) = self.model_step(batch)
 
         # update and log metrics
@@ -508,6 +526,9 @@ class TANRModule(AbstractRecommneder):
         cand_indexes = torch.arange(cand_news_size.shape[0]).repeat_interleave(cand_news_size)
         hist_indexes = torch.arange(hist_news_size.shape[0]).repeat_interleave(hist_news_size)
 
+        user_ids = self._gather_step_outputs(self.test_step_outputs, "user_ids")
+        cand_news_ids = self._gather_step_outputs(self.test_step_outputs, "cand_news_ids")
+
         # update metrics
         self.test_rec_metrics(preds, targets, **{"indexes": cand_indexes})
         self.test_categ_div_metrics(preds, target_categories, cand_indexes)
@@ -535,6 +556,19 @@ class TANRModule(AbstractRecommneder):
         self.log_dict(
             self.test_sent_pers_metrics, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
+
+        # save recommendations
+        if self.hparams.save_recs:
+            recommendations_dico = self._get_recommendations(
+                user_ids=user_ids,
+                news_ids=cand_news_ids,
+                scores=preds,
+                cand_news_size=cand_news_size,
+            )
+            print(recommendations_dico)
+            self._save_recommendations(
+                recommendations=recommendations_dico, fpath=self.hparams.recs_fpath
+            )
 
         # clear memory for the next epoch
         self.test_step_outputs = self._clear_epoch_outputs(self.test_step_outputs)

--- a/tests/test_datamodules.py
+++ b/tests/test_datamodules.py
@@ -116,7 +116,7 @@ def test_mind_rec_small_datamodule(batch_size):
 
     batch = next(iter(dm.train_dataloader()))
 
-    assert len(batch["users"]) == batch_size
+    assert len(batch["user_idx"]) == batch_size
 
 
 @pytest.mark.parametrize("batch_size", [8, 64])
@@ -223,4 +223,4 @@ def test_adressa_rec_small_datamodule(batch_size):
 
     batch = next(iter(dm.train_dataloader()))
 
-    assert len(batch["users"]) == batch_size
+    assert len(batch["user_idx"]) == batch_size


### PR DESCRIPTION
Proposing to add functionality to save the list of _not ranked_ recommendations (i.e., predicted candidate news and corresponding scores) for each user in JSON format.

Pull request adressing:
- 5ccc9f83e07529e5ce43295b026d3f7c0991506e - Streamlining how user IDs (from original dataset) and user indices (e.g., for indexing user embedding matrix) are handled across datasets.
- bbf494bbd06bc98acda9124ccc58526bc760b75c - Adds functions to retrieve and save recommendations for given users and predictions in `AbstractRecomender`.
- e0a1baab85930f3aa067544de51d54d7c05d0ae2 - Add explicit news IDs to batch to be passed to the model.
- eca9f54f6c7c9dee72868ba7c84b0bdc64464ddc - Update models with option to save the recommendation lists for the users in the test set on `on_test_epoch_end`.
- 1b33d384ea5b3e77d1c8c78e206e9a6129bf768e - Update model configurations to reflect changes in the model hyperparameters for saving the recommendations lists.