### PR TITLE
MIND dataset URLs update

### DIFF
--- a/configs/data/mind_news.yaml
+++ b/configs/data/mind_news.yaml
@@ -5,11 +5,11 @@ dataset_size: large # choose from 'large' or 'small'
 # URLs for downloading the dataset
 dataset_url:
   large:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDlarge_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDlarge_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_dev.zip"
   small:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDsmall_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDsmall_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_dev.zip"
 pretrained_embeddings_url: "https://nlp.stanford.edu/data/glove.840B.300d.zip"
 
 # File names and paths

--- a/configs/data/mind_rec.yaml
+++ b/configs/data/mind_rec.yaml
@@ -5,11 +5,11 @@ dataset_size: large # choose from 'large' or 'small'
 # URLs for downloading the dataset
 dataset_url:
   large:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDlarge_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDlarge_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_dev.zip"
   small:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDsmall_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDsmall_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_dev.zip"
 pretrained_embeddings_url: "https://nlp.stanford.edu/data/glove.840B.300d.zip"
 
 # File names and paths

--- a/configs/data/xmind_rec.yaml
+++ b/configs/data/xmind_rec.yaml
@@ -6,11 +6,11 @@ dataset_size: large # choose from 'large' or 'small'
 # URLs for downloading the MIND dataset
 mind_dataset_url:
   large:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDlarge_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDlarge_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_dev.zip"
   small:
-    train: "https://mind201910small.blob.core.windows.net/release/MINDsmall_train.zip"
-    dev: "https://mind201910small.blob.core.windows.net/release/MINDsmall_dev.zip"
+    train: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_train.zip"
+    dev: "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_dev.zip"
 
 # File names and paths
 data_dir: ${paths.data_dir}

--- a/newsreclib/data/components/mind_dataframe.py
+++ b/newsreclib/data/components/mind_dataframe.py
@@ -148,8 +148,7 @@ class MINDDataFrame(Dataset):
                 clean_archive=False,
             )
 
-            if False:
-            # if not self.use_plm or self.use_pretrained_categ_embeddings:
+            if not self.use_plm or self.use_pretrained_categ_embeddings:
                 assert isinstance(pretrained_embeddings_url, str)
                 assert isinstance(word_embeddings_dirname, str)
                 assert isinstance(word_embeddings_fpath, str)

--- a/newsreclib/data/components/mind_dataframe.py
+++ b/newsreclib/data/components/mind_dataframe.py
@@ -148,7 +148,8 @@ class MINDDataFrame(Dataset):
                 clean_archive=False,
             )
 
-            if not self.use_plm or self.use_pretrained_categ_embeddings:
+            if False:
+            # if not self.use_plm or self.use_pretrained_categ_embeddings:
                 assert isinstance(pretrained_embeddings_url, str)
                 assert isinstance(word_embeddings_dirname, str)
                 assert isinstance(word_embeddings_fpath, str)
@@ -233,8 +234,12 @@ class MINDDataFrame(Dataset):
                 "title_entities",
                 "abstract_entities",
             ]
+            # The output folder is actually wrapped in a subdir of the same name
+            # TODO: There is probably a nicer way to handle this
+            subdir = os.path.split(os.path.dirname(parsed_news_file))[-1]
+
             news = pd.read_table(
-                filepath_or_buffer=os.path.join(self.dst_dir, "news.tsv"),
+                filepath_or_buffer=os.path.join(self.dst_dir, subdir, "news.tsv"),
                 header=None,
                 names=columns_names,
                 usecols=range(len(columns_names)),

--- a/tests/test_datamodules.py
+++ b/tests/test_datamodules.py
@@ -12,13 +12,13 @@ def test_mind_rec_small_datamodule(batch_size):
     dataset_size = "small"  # URLs for downloading the dataset
     dataset_url = {
         "large": {
-            "train": "https://mind201910small.blob.core.windows.net/release/MINDlarge_train.zip",
-            "dev": "https://mind201910small.blob.core.windows.net/release/MINDlarge_dev.zip",
+            "train": "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_train.zip",
+            "dev": "https://recodatasets.z20.web.core.windows.net/newsrec/MINDlarge_dev.zip"
         },
-        "small": {
-            "train": "https://mind201910small.blob.core.windows.net/release/MINDsmall_train.zip",
-            "dev": "https://mind201910small.blob.core.windows.net/release/MINDsmall_dev.zip",
-        },
+        "small":
+            "train": "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_train.zip"
+            "dev": "https://recodatasets.z20.web.core.windows.net/newsrec/MINDsmall_dev.zip"
+        }
     }
     pretrained_embeddings_url = "https://nlp.stanford.edu/data/glove.840B.300d.zip"
     data_dir = "data/"


### PR DESCRIPTION
It seems that the old MIND dataset URL are now defunct. I reached out to one of the authors and they pointed me to a new set of URLs which I have updated. I am testing it now with`experiment=nrms_mindsmall_pretrainedemb_celoss_bertsent` but have updated other URLs including the tests, but not sure if that works as expecting
